### PR TITLE
Update checkRegex in ngOnInit to use updated config properties

### DIFF
--- a/projects/ngx-scanner-detection/src/lib/scanner-detection.component.ts
+++ b/projects/ngx-scanner-detection/src/lib/scanner-detection.component.ts
@@ -53,7 +53,7 @@ export class ScannerDetectionComponent implements OnInit {
   }
 
   public ngOnInit(): void {
-
+    this.checkRegex = new RegExp(`^${this._config.scannerStartsWith}${this._config.allowNotNumber ? '.' : '\\d'}{${this._config.minLength},${this._config.maxLength}}${this._config.scannerEndsWith}$`);
   }
 
 }


### PR DESCRIPTION
Due to variables initiation orders, checkRegex use default config.
[Moving checkRegex into ngOnInit will use updated config. ](https://github.com/baao/ngx-scanner-detection/issues/1#issuecomment-615115595)